### PR TITLE
Moved file.date outside the filename if() statement

### DIFF
--- a/R/write_arlequin.R
+++ b/R/write_arlequin.R
@@ -104,9 +104,9 @@ write_arlequin <- function(
   # Write the file in arlequin format -----------------------------------------
   
   # Filename
+  # Get date and time to have unique filenaming
+  file.date <- stringi::stri_replace_all_fixed(Sys.time(), pattern = " EDT", replacement = "", vectorize_all = FALSE)
   if (is.null(filename)) {
-    # Get date and time to have unique filenaming
-    file.date <- stringi::stri_replace_all_fixed(Sys.time(), pattern = " EDT", replacement = "", vectorize_all = FALSE)
     file.date <- stringi::stri_replace_all_fixed(file.date, pattern = c("-", " ", ":"), replacement = c("", "@", ""), vectorize_all = FALSE)
     file.date <- stringi::stri_sub(file.date, from = 1, to = 13)
     filename <- stringi::stri_join("radiator_arlequin_", file.date, ".arp")


### PR DESCRIPTION
The current formatted time (saved in `file.date`) is used in the 'Title' section of the file (see below) and therefor required even if a `filename` is provided:
```
write(paste('Title = "radiator_arlequin_export', " ", file.date, '"'), file = filename.connection, append = TRUE)
```
Without this patch, the function fails, giving a `object file.date not found` error.