### PR TITLE
Bug/change alleles

### DIFF
--- a/R/change_alleles.R
+++ b/R/change_alleles.R
@@ -358,7 +358,7 @@ integrate_ref <- function(
           A2_NUC = stringi::stri_pad_left(str = A2_NUC, pad = "0", width = 3)
         ) %>%
         tidyr::unite(data = ., col = GT, A1_NUC, A2_NUC, sep = "") %>%
-        dplyr::select(-A1, -A2)
+        tidyr::unite(data = ., col = ORIG_GT, A1, A2, sep = "")
 
       if (biallelic) {
         res <- res %>%
@@ -390,10 +390,13 @@ integrate_ref <- function(
     dplyr::bind_rows(.)
 
   if (nuc.info) {
-    x <- dplyr::left_join(x, new.gt, by = c("MARKERS", "GT_VCF_NUC"))
+    x <- dplyr::left_join(x, new.gt, by = c("MARKERS", "GT_VCF_NUC")) %>%
+      dplyr::select(-ORIG_GT)
   } else {
     if (tibble::has_name(x, "GT_VCF")) x <- dplyr::select(x, -GT_VCF)
-    x <- dplyr::left_join(x, new.gt, by = c("MARKERS", "GT"))
+    x <- dplyr::left_join(rename(x, ORIG_GT = GT), new.gt, by = c("MARKERS", "ORIG_GT")) %>%
+      dplyr::select(-GT) %>%
+      dplyr::rename(GT = ORIG_GT)
   }
   return(x)
 } #End integrate_ref

--- a/R/change_alleles.R
+++ b/R/change_alleles.R
@@ -158,6 +158,7 @@ change_alleles <- function(
     message("    Number of markers with REF/ALT change(s) = ", nrow(change.ref))
   } else {
     inversion <- FALSE # not yet used
+    change.ref <- NULL
   }
 
   if (tibble::has_name(data, "REF")) {
@@ -176,7 +177,7 @@ change_alleles <- function(
   conversion.df <- NULL
 
   # switch ALLELE_REF_DEPTH/ALLELE_ALT_DEPTH
-  if (nrow(change.ref) > 0 & tibble::has_name(data, "ALLELE_REF_DEPTH")) {
+  if (!is.null(change.ref) & tibble::has_name(data, "ALLELE_REF_DEPTH")) {
     data <- data %>%
       dplyr::mutate(
         ALLELE_REF_DEPTH_NEW = dplyr::if_else(

--- a/R/detect_biallelic_markers.R
+++ b/R/detect_biallelic_markers.R
@@ -79,11 +79,17 @@ detect_biallelic_markers <- function(data, verbose = FALSE) {
     }
     alt.num <- NULL
   } else {
-    # 10% of the markers are randomly sampled
-    sampled.markers <- unique(input$MARKERS)
-    sampled.markers <- sample(x = sampled.markers,
-                              size = length(sampled.markers) * 0.10,
-                              replace = FALSE)
+
+    # If there are less than 100 markers, sample all of them
+    if (length(unique(input$MARKERS)) < 100) {
+      sampled.markers <- unique(input$MARKERS)
+    } else {
+      # otherwise 10% of the markers are randomly sampled
+      sampled.markers <- unique(input$MARKERS)
+      sampled.markers <- sample(x = sampled.markers,
+                                size = length(sampled.markers) * 0.10,
+                                replace = FALSE)
+    }
 
     # system.time(input2 <- dplyr::select(.data = input, MARKERS, GT) %>%
     #   dplyr::filter(GT != "000000") %>%
@@ -114,7 +120,7 @@ detect_biallelic_markers <- function(data, verbose = FALSE) {
     biallelic <- max(biallelic$n)
     # if (length(biallelic) != 1) stop("Mix of bi- and multi-allelic markers is not supported")
 
-    if (biallelic > 4) {
+    if (biallelic > 2) {
       biallelic <- FALSE
       if (verbose) message("    Data is multi-allelic")
     } else {


### PR DESCRIPTION
Hi Thierry,

Thanks for all of the work on this. I was still having some problems with the most recent commit. I think I fixed them, as well as a problem that emerged when I was tested a second example with the nancycats data from adegenet. Basically, VCF-style genotypes were not being created when alleles were not coded as 1-based integers (as in microsat datasets, where alleles are often coded as fragment sizes). I've recorded my steps below:

``` r
library(tidyverse)
library(devtools)
library(adegenet)

# Installing the most recent commit
devtools::install_github("thierrygosselin/radiator", ref = "aa1aefc")
library(radiator)

# A sample tidy multi-allelic data frame
tidy_dat2 <- tibble::tribble(
  ~INDIVIDUALS, ~POP_ID, ~LOCUS, ~GT,
  "IND1",    "POP1",  "loc1", "000000",
  "IND2",    "POP1",  "loc1", "001002",
  "IND3",    "POP1",  "loc1", "003004"
)


# There's still an error in running this small test dataset
change_alleles(tidy_dat2, verbose = TRUE)
#> Warning in max(biallelic$n): no non-missing arguments to max; returning -
#> Inf
#>     Data is biallellic
#>     Generating REF/ALT dictionary
#>     Integrating new genotype codings...

#> Error in nrow(change.ref): object 'change.ref' not found

detect_biallelic_markers(tidy_dat2)
#> Warning in max(biallelic$n): no non-missing arguments to max; returning -
#> Inf
#> [1] TRUE


# The first problem that I can see is in the change_alleles() function. Specifically,
# if there is no REF info (the tidy data frame comes from a genind or genepop-type source)
# the variable 'change.ref' is never defined, which causes an error in evaluation later

# The second problem is that the function detect_biallelic_markers() is reading this dataset as
# biallelic

# I made some changes to fix these two things
devtools::install_github("chollenbeck/radiator", ref = "cbb575d")
#> Downloading GitHub repo chollenbeck/radiator@cbb575d
#> from URL https://api.github.com/repos/chollenbeck/radiator/zipball/cbb575d
#> Installing radiator
#> "C:/PROGRA~1/R/R-34~1.1/bin/i386/R" --no-site-file --no-environ  \
#>   --no-save --no-restore --quiet CMD INSTALL  \
#>   "C:/Users/ch263/AppData/Local/Temp/RtmpMbbVPG/devtoolsa8028937f50/chollenbeck-radiator-cbb575d"  \
#>   --library="C:/Users/ch263/R/win-library/3.4" --install-tests
#> 
#> Reloading installed radiator

# This fix to detect_biallelic_markers corrects the biallelic designation
detect_biallelic_markers(tidy_dat2)
#> [1] FALSE

# Now the change_alleles function is producing the correct output
change_alleles(tidy_dat2, verbose = TRUE)
#>     Data is multiallellic
#>     Generating REF/ALT dictionary
#>     Integrating new genotype codings...
#> $input
#> # A tibble: 3 x 7
#>   MARKERS POP_ID INDIVIDUALS     GT   REF         ALT GT_VCF
#>     <chr>  <chr>       <chr>  <chr> <chr>       <chr>  <chr>
#> 1    loc1   POP1        IND1 000000   001 002,003,004    ./.
#> 2    loc1   POP1        IND2 001002   001 002,003,004    0/1
#> 3    loc1   POP1        IND3 003004   001 002,003,004    2/3
#> 
#> $biallelic
#> [1] FALSE

# Try to tidy the nancycats dataset to see if this will work for a scaled-up example
data("nancycats")
cats <- tidy_genomic_data(nancycats)
#> #######################################################################
#> ##################### radiator::tidy_genomic_data #####################
#> #######################################################################
#> Tidying the genind object ...
#>     Data is multiallellic
#>     Generating REF/ALT dictionary
#>     Integrating new genotype codings...
#> Erasing genotype: no
#> Warning: Unknown variables: `CHROM`, `LOCUS`, `POS`
#> Using markers common in all populations:
#>     Number of markers before = 9
#>     Number of markers removed = 1
#>     Number of markers after (common between populations) = 8
#> Warning: Unknown variables: `CHROM`, `LOCUS`, `POS`
#> Removing monomorphic markers: yes
#> Scanning for monomorphic markers...
#>     Number of markers before = 8
#>     Number of monomorphic markers removed = 0
#> Warning: Unknown variables: `CHROM`, `LOCUS`, `POS`
#> ############################### RESULTS ###############################
#> Tidy data written in global environment
#> Data format: tbl_df
#> Multiallelic data
#> Number of common markers: 8
#> Number of chromosome/contig/scaffold: no chromosome info
#> Number of individuals: 237
#> Number of populations: 17
#> Computation time: 40 sec
#> ################ radiator::tidy_genomic_data completed ################

# It looks like the GT_VCF format is <NA> for non_missing observations
head(cats)
#>   MARKERS POP_ID INDIVIDUALS     GT REF
#> 1    fca8    P01        N215 000000 135
#> 2    fca8    P01        N216 000000 135
#> 3    fca8    P01        N217 135143 135
#> 4    fca8    P01        N218 133135 135
#> 5    fca8    P01        N219 133135 135
#> 6    fca8    P01        N220 135143 135
#>                                                           ALT GT_VCF
#> 1 137,143,141,133,123,139,131,129,145,149,121,147,117,119,127    ./.
#> 2 137,143,141,133,123,139,131,129,145,149,121,147,117,119,127    ./.
#> 3 137,143,141,133,123,139,131,129,145,149,121,147,117,119,127   <NA>
#> 4 137,143,141,133,123,139,131,129,145,149,121,147,117,119,127   <NA>
#> 5 137,143,141,133,123,139,131,129,145,149,121,147,117,119,127   <NA>
#> 6 137,143,141,133,123,139,131,129,145,149,121,147,117,119,127   <NA>

# It looks like the problem is in the nested integrate_ref() function in change_alleles().
# When alleles are not coded as 1-based integers (001001), such as in a microsat dataset like
# nancycats (where alleles are coded as 135143, etc.), the final join function fails because the
# join is based on the new recoded genotypes (i.e. 135135 becomes 001001 if the REF allele is 135).
# If the join is based on the original genotype column rather than the new column, the join is successful.

# Made a new change to attempt to fix this problem
devtools::install_github("chollenbeck/radiator", ref = "b0cacf6")
#> Downloading GitHub repo chollenbeck/radiator@b0cacf6
#> from URL https://api.github.com/repos/chollenbeck/radiator/zipball/b0cacf6
#> Installing radiator
#> "C:/PROGRA~1/R/R-34~1.1/bin/i386/R" --no-site-file --no-environ  \
#>   --no-save --no-restore --quiet CMD INSTALL  \
#>   "C:/Users/ch263/AppData/Local/Temp/RtmpMbbVPG/devtoolsa802ac734aa/chollenbeck-radiator-b0cacf6"  \
#>   --library="C:/Users/ch263/R/win-library/3.4" --install-tests
#> 
#> Reloading installed radiator

# It looks like this is working now
cats <- tidy_genomic_data(nancycats)
#> #######################################################################
#> ##################### radiator::tidy_genomic_data #####################
#> #######################################################################
#> Tidying the genind object ...
#>     Data is multiallellic
#>     Generating REF/ALT dictionary
#>     Integrating new genotype codings...
#> Erasing genotype: no
#> Warning: Unknown variables: `CHROM`, `LOCUS`, `POS`
#> Using markers common in all populations:
#>     Number of markers before = 9
#>     Number of markers removed = 1
#>     Number of markers after (common between populations) = 8
#> Warning: Unknown variables: `CHROM`, `LOCUS`, `POS`
#> Removing monomorphic markers: yes
#> Scanning for monomorphic markers...
#>     Number of markers before = 8
#>     Number of monomorphic markers removed = 0
#> Warning: Unknown variables: `CHROM`, `LOCUS`, `POS`
#> ############################### RESULTS ###############################
#> Tidy data written in global environment
#> Data format: tbl_df
#> Multiallelic data
#> Number of common markers: 8
#> Number of chromosome/contig/scaffold: no chromosome info
#> Number of individuals: 237
#> Number of populations: 17
#> Computation time: 43 sec
#> ################ radiator::tidy_genomic_data completed ################
head(cats)
#>   MARKERS POP_ID INDIVIDUALS     GT REF
#> 1    fca8    P01        N215 000000 135
#> 2    fca8    P01        N216 000000 135
#> 3    fca8    P01        N217 135143 135
#> 4    fca8    P01        N218 133135 135
#> 5    fca8    P01        N219 133135 135
#> 6    fca8    P01        N220 135143 135
#>                                                           ALT GT_VCF
#> 1 137,143,141,133,123,139,131,129,145,149,121,147,117,119,127    ./.
#> 2 137,143,141,133,123,139,131,129,145,149,121,147,117,119,127    ./.
#> 3 137,143,141,133,123,139,131,129,145,149,121,147,117,119,127    0/2
#> 4 137,143,141,133,123,139,131,129,145,149,121,147,117,119,127    4/0
#> 5 137,143,141,133,123,139,131,129,145,149,121,147,117,119,127    4/0
#> 6 137,143,141,133,123,139,131,129,145,149,121,147,117,119,127    0/2

# Check the small example now to make sure this is unaffected
change_alleles(tidy_dat2, verbose = TRUE)
#>     Data is multiallellic
#>     Generating REF/ALT dictionary
#>     Integrating new genotype codings...
#> $input
#> # A tibble: 3 x 7
#>   MARKERS POP_ID INDIVIDUALS     GT   REF         ALT GT_VCF
#>     <chr>  <chr>       <chr>  <chr> <chr>       <chr>  <chr>
#> 1    loc1   POP1        IND1 000000   001 002,003,004    ./.
#> 2    loc1   POP1        IND2 001002   001 002,003,004    0/1
#> 3    loc1   POP1        IND3 003004   001 002,003,004    2/3
#> 
#> $biallelic
#> [1] FALSE

# Looks good
```
