### PR TITLE
Update tidy_genlight.R

### DIFF
--- a/R/tidy_genlight.R
+++ b/R/tidy_genlight.R
@@ -181,7 +181,7 @@ tidy_genlight <- function(
             vectorize_all = FALSE
           ),
           INDIVIDUALS = radiator::clean_ind_names(INDIVIDUALS),
-          POP_ID = radiator::clean_pop_names(POP_ID)
+          POP_ID = radiator::clean_pop_names(STRATA)
         ) %>%
         dplyr::arrange(MARKERS, POP_ID, INDIVIDUALS) %>%
         dplyr::select(dplyr::one_of(want)))


### PR DESCRIPTION
* edit POP_ID error
Change the POP_ID label by STRATA (The object strata, which is merged with geno data to add info of population, has the label STRATA instead of POP_ID)
