### PR TITLE
filter.common.markers arg in tidy_genomic_data

### DIFF
--- a/R/radiator_tidy.R
+++ b/R/radiator_tidy.R
@@ -501,7 +501,8 @@ tidy_genomic_data <- function(
       gt.bin = TRUE,
       path.folder = path.folder,
       internal = TRUE,
-      tidy.check = FALSE
+      tidy.check = FALSE,
+      filter.common.markers = filter.common.markers
     )
     biallelic <- radiator::detect_biallelic_markers(input)
   } # End import VCF


### PR DESCRIPTION
Added filter.common.markers = filter.common.markers to tidy_vcf(), otherwise running tidy_genomic_data() would filter common markers even if filter.common.markers=FALSE